### PR TITLE
add relative dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Y    M    W    D
 h    m    s    ms    us    ns
 examples: 1Y2M3W4D5h6m7s8ms9us1ns, "1Y 2M 3W 4D 5h 6m 7s 8ms 9us 1ns"
 
+Relative Dates:
+for the -s, -e, -F, and -U flags, you can use these shortcuts:
+now
+today (returns same value as now)
+yesterday
+tomorrow
+example: dtdiff -F today -A 7h10m -U tomorrow
 ```
 
 **Note:** The `-i` switch can accept two different types of input:
@@ -203,6 +210,16 @@ $ dtdiff -F 15:20 -S 5m -U 15:00
 2024-06-30 15:10:00 -0400 EDT
 2024-06-30 15:05:00 -0400 EDT
 2024-06-30 15:00:00 -0400 EDT
+
+# use relative date until tomorrow
+$ dtdiff -F today -A 7h10m -U tomorrow 
+2024-07-03 14:29:28 -0400 EDT
+2024-07-03 21:39:28 -0400 EDT
+2024-07-04 04:49:28 -0400 EDT
+
+# use relative start date with brief output
+$ dtdiff -s today -e 2024-07-07 -b
+3D16h38m47s
 ```
 
 ## LICENSE

--- a/cmd/dtdiff/main.go
+++ b/cmd/dtdiff/main.go
@@ -40,8 +40,15 @@ Brief Durations: (dates are upper, times are lower)
 Y    M    W    D
 h    m    s    ms    us    ns
 examples: 1Y2M3W4D5h6m7s8ms9us1ns, "1Y 2M 3W 4D 5h 6m 7s 8ms 9us 1ns"
-{{end}}{{if .HasAvailableInheritedFlags}}
 
+Relative Dates:
+for the -s, -e, -F, and -U flags, you can use these shortcuts:
+now
+today (returns same value as now)
+yesterday
+tomorrow
+example: dtdiff -F today -A 7h10m -U tomorrow
+{{end}}{{if .HasAvailableInheritedFlags}}
 Global Flags:
  {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}

--- a/dtdiff_test.go
+++ b/dtdiff_test.go
@@ -1,6 +1,8 @@
 package dtdiff
 
 import (
+	"fmt"
+	"github.com/golang-module/carbon/v2"
 	"strings"
 	"testing"
 )
@@ -234,7 +236,7 @@ func TestAddUntil(t *testing.T) {
 	from := "2024-06-28T04:25:41Z"
 	period := "1M1W1h1m2s"
 	until := "2024-10-18 07:28:47"
-	allCorrectAdd := []string{"2024-08-04 05:26:43", "2024-09-11 06:27:45", "2024-10-18 07:28:47", "x"}
+	allCorrectAdd := []string{"2024-08-04 05:26:43", "2024-09-11 06:27:45", "2024-10-18 07:28:47"}
 	testAddUntil(t, from, until, period, allCorrectAdd)
 }
 
@@ -244,4 +246,37 @@ func TestSubUntil(t *testing.T) {
 	until := "2024-05-28T04:25:41Z"
 	allCorrectSub := []string{"2024-09-11 06:27:45", "2024-08-04 05:26:43", "2024-06-27 04:25:41"}
 	testSubUntil(t, from, until, period, allCorrectSub)
+}
+
+func TestRelativeStartEnd(t *testing.T) {
+	start := "yesterday"
+	end := "Today"
+	correct := "1 day"
+	testStartEnd(t, start, end, correct)
+
+	start = "Yesterday"
+	end = "tomorrow"
+	correct = "2 days"
+	testStartEnd(t, start, end, correct)
+
+	start = "now"
+	end = "today"
+	correct = "0 seconds"
+	testStartEnd(t, start, end, correct)
+
+	start = "today"
+	end = "tomorrow"
+	correct = "1 day"
+	testStartEnd(t, start, end, correct)
+}
+
+func TestRelativeUntil(t *testing.T) {
+	from := carbon.Now().StartOfDay().ToDateTimeString()
+	period := "7h59m1s"
+	until := "tomorrow"
+	allCorrectAdd := []string{"", "", ""}
+	allCorrectAdd[0] = fmt.Sprintf("%s", strings.Replace(from, "00:00:00", "07:59:01", 1))
+	allCorrectAdd[1] = fmt.Sprintf("%s", strings.Replace(from, "00:00:00", "15:58:02", 1))
+	allCorrectAdd[2] = fmt.Sprintf("%s", strings.Replace(from, "00:00:00", "23:57:03", 1))
+	testAddUntil(t, from, until, period, allCorrectAdd)
 }


### PR DESCRIPTION
## Relative Dates

for the `-s`, `-e`, `-F`, and `-U` flags, you can now use these shortcuts:
* now
* today (returns same value as now)
* yesterday
* tomorrow
* example: `dtdiff -F today -A 7h10m -U tomorrow`

Also removed duplicate code for the `carbonFuncs` map.
